### PR TITLE
Fix: add workaround about firefox flexbox bug

### DIFF
--- a/src/views/containers/alarm.vue
+++ b/src/views/containers/alarm.vue
@@ -51,5 +51,6 @@ export default class Alarm extends Vue {
 .rk-alarm {
   flex-grow: 1;
   height: 100%;
+  min-height: 0;
 }
 </style>

--- a/src/views/containers/topology.vue
+++ b/src/views/containers/topology.vue
@@ -62,6 +62,7 @@ export default class Topology extends Vue {
 .rk-topo{
   position: relative;
   height: 100%;
+  min-height: 0;
   display: flex;
   background: #333840;
 }

--- a/src/views/containers/trace.vue
+++ b/src/views/containers/trace.vue
@@ -58,9 +58,11 @@ export default class Trace extends Vue {
 .rk-trace {
   flex-grow: 1;
   height: 100%;
+  min-height: 0;
 }
 .rk-trace-inner{
   height: 100%;
   display: flex;
+  min-height: 0;
 }
 </style>


### PR DESCRIPTION
The flex items cannot shrink to proper height in Firefox.
Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1043520

Unexpected behavior:
![buggy UI](https://user-images.githubusercontent.com/7829098/57354858-3ede3700-719f-11e9-9b72-85c7d969b4b5.jpg)

Fixed:
![added workaround UI](https://user-images.githubusercontent.com/7829098/57354875-4dc4e980-719f-11e9-9890-abea03042bcd.png)
