### PR TITLE
disabled select operation when tab is not active

### DIFF
--- a/src/views/components/dashboard/tool-bar-endpoint-select.vue
+++ b/src/views/components/dashboard/tool-bar-endpoint-select.vue
@@ -16,8 +16,8 @@
  */
 
 <template>
-  <div class="rk-dashboard-bar-select cp flex-h" v-clickout="() => {search = ''; visible = false;}" :class="{'active':visible}">
-    <div class="rk-dashboard-bar-i flex-h" @click="visible = !visible;SEARCH_ENDPOINTS('');">
+  <div class="rk-dashboard-bar-select cp flex-h" v-clickout="() => {search = ''; visible = false;}" :class="{'active':visible, 'disable-select': disabled}">
+    <div class="rk-dashboard-bar-i flex-h" @click="clickEvent">
       <svg class="icon lg mr-15">
         <use :xlink:href="`#${icon}`"></use>
       </svg>
@@ -54,6 +54,7 @@ export default class ToolBarEndpointSelect extends Vue {
   @Prop() public current!: any;
   @Prop() public title!: string;
   @Prop() public icon!: string;
+  @Prop() public disabled!: string; 
   public search: string = '';
   public visible: boolean = false;
   public handleSearch() {
@@ -66,10 +67,21 @@ export default class ToolBarEndpointSelect extends Vue {
     this.$emit('onChoose', i);
     this.visible = false;
   }
+  public clickEvent() {
+    if (this.disabled) {
+      return 
+    }
+    this.visible = !this.visible;
+    this.SEARCH_ENDPOINTS('');
+  }
 }
 </script>
 
 <style lang="scss" scoped>
+.disable-select {
+  cursor: not-allowed;
+  color: #a7aebb;
+}
 .rk-dashboard-bar-select {
   position: relative;
   z-index: 1;

--- a/src/views/components/dashboard/tool-bar-select.vue
+++ b/src/views/components/dashboard/tool-bar-select.vue
@@ -17,8 +17,8 @@
 
 <template>
   <div class="rk-dashboard-bar-select flex-h" v-clickout="() => { visible = false;search = '';}"
-       :class="{'active':visible, 'cp': selectable, 'cd': !selectable}">
-    <div class="rk-dashboard-bar-i flex-h" @click="selectable && (visible = !visible)">
+       :class="{'active':visible, 'cp': selectable, 'cd': !selectable, 'disable-select': disabled}">
+    <div class="rk-dashboard-bar-i flex-h" @click="clickEvent">
       <svg class="icon lg mr-15">
         <use :xlink:href="`#${icon}`"></use>
       </svg>
@@ -52,6 +52,7 @@ export default class ToolBarSelect extends Vue {
   @Prop() public current!: any;
   @Prop() public title!: string;
   @Prop() public icon!: string;
+  @Prop() public disabled: any;
   @Prop({type: Boolean, default: true}) public selectable!: boolean;
   public search: string = '';
   public visible: boolean = false;
@@ -65,10 +66,22 @@ export default class ToolBarSelect extends Vue {
     this.$emit('onChoose', i);
     this.visible = false;
   }
+  public clickEvent() {
+    if (this.disabled) {
+      return
+    }
+    if (this.selectable) {
+      this.visible = !this.visible
+    }
+  }
 }
 </script>
 
 <style lang="scss" scoped>
+.disable-select {
+  cursor: not-allowed;
+  color: #a7aebb;
+}
 .rk-dashboard-bar-select {
   position: relative;
   z-index: 1;

--- a/src/views/components/dashboard/tool-bar.vue
+++ b/src/views/components/dashboard/tool-bar.vue
@@ -24,9 +24,9 @@
       <div class="rk-dashboard-bar-reload">
         <svg class="icon lg vm cp rk-btn ghost" @click="handleOption"><use xlink:href="#retry"></use></svg>
       </div>
-      <ToolBarSelect @onChoose="selectService" :title="this.$t('currentService')" :current="stateDashboard.currentService" :data="stateDashboard.services" icon="package"/>
-      <ToolBarEndpointSelect @onChoose="selectEndpoint" :title="this.$t('currentEndpoint')" :current="stateDashboard.currentEndpoint" :data="stateDashboard.endpoints" icon="code"/>
-      <ToolBarSelect @onChoose="selectInstance" :title="this.$t('currentInstance')" :current="stateDashboard.currentInstance" :data="stateDashboard.instances" icon="disk"/>
+      <ToolBarSelect :disabled="isDisabledService" @onChoose="selectService" :title="this.$t('currentService')" :current="stateDashboard.currentService" :data="stateDashboard.services" icon="package"/>
+      <ToolBarEndpointSelect :disabled="isDisabledEndpoint" @onChoose="selectEndpoint" :title="this.$t('currentEndpoint')" :current="stateDashboard.currentEndpoint" :data="stateDashboard.endpoints" icon="code"/>
+      <ToolBarSelect :disabled="isDisabledInstacnce" @onChoose="selectInstance" :title="this.$t('currentInstance')" :current="stateDashboard.currentInstance" :data="stateDashboard.instances" icon="disk"/>
     </div>
     <div class="rk-dashboard-bar flex-h" v-if="compType === 'proxy'">
       <div class="rk-dashboard-bar-reload">
@@ -43,7 +43,7 @@
       <div class="rk-dashboard-bar-reload">
         <svg class="icon lg vm cp rk-btn ghost" @click="handleOption"><use xlink:href="#retry"></use></svg>
       </div>
-      <ToolBarSelect @onChoose="SELECT_DATABASE" :title="this.$t('currentDatabase')" :current="stateDashboard.currentDatabase" :data="stateDashboard.databases" icon="epic"/>
+      <ToolBarSelect :disabled="isDisabledDatabse" @onChoose="SELECT_DATABASE" :title="this.$t('currentDatabase')" :current="stateDashboard.currentDatabase" :data="stateDashboard.databases" icon="epic"/>
     </div>
   </div>
 </template>
@@ -56,6 +56,7 @@ import { State, Action, Mutation } from 'vuex-class';
 @Component({components: {ToolBarSelect, ToolBarEndpointSelect}})
 export default class ToolBar extends Vue {
   @Prop() private compType!: any;
+  @Prop() private compIndex!: any;
   @Prop() private stateDashboard!: any;
   @Prop() private rocketGlobal!: any;
   @Prop() private rocketComps!: any;
@@ -67,6 +68,33 @@ export default class ToolBar extends Vue {
   @Action('SELECT_ENDPOINT') private SELECT_ENDPOINT: any;
   @Action('SELECT_INSTANCE') private SELECT_INSTANCE: any;
   @Action('MIXHANDLE_GET_OPTION') private MIXHANDLE_GET_OPTION: any;
+  private compServiceIndexMap :any = {
+    'Global': 0,
+    'Service': 1,
+    'Endpoint': 2,
+    'Instance': 3
+  }
+  private compDatabaseIndexMap: any = {
+    'Global': 0,
+    'Database': 1,
+  }
+  get isDisabledService() {
+    let { Global: globalIndex } = this.compServiceIndexMap
+    console.log([globalIndex].includes(this.compIndex), globalIndex, this.compIndex, 'kevinkang--->>>>')
+    return [globalIndex].includes(this.compIndex)
+  }
+  get isDisabledEndpoint() {
+    let { Global: globalIndex, Service: serviceIndex } = this.compServiceIndexMap
+    return [globalIndex, serviceIndex].includes(this.compIndex)
+  }
+  get isDisabledInstacnce() {
+    let { Global: globalIndex, Service: serviceIndex, Endpoint: endpointIndex } = this.compServiceIndexMap
+    return [globalIndex, serviceIndex, endpointIndex].includes(this.compIndex)
+  }
+  get isDisabledDatabse() {
+    let { Global: globalIndex} = this.compDatabaseIndexMap
+    return [globalIndex].includes(this.compIndex)
+  }
   get lastKey() {
     const current = this.rocketComps.tree[this.rocketComps.group]
     .children[this.rocketComps.current].children;

--- a/src/views/containers/dashboard.vue
+++ b/src/views/containers/dashboard.vue
@@ -18,7 +18,7 @@
 <template>
   <div class="flex-v wrapper" style="flex-grow:1;height: 100%;">
     <ToolGroup :rocketGlobal="rocketGlobal" :rocketComps="rocketComps"/>
-    <ToolBar :rocketGlobal="rocketGlobal" :compType="compType" :durationTime="durationTime"  :stateDashboard='stateDashboardOption'/>
+    <ToolBar :rocketGlobal="rocketGlobal" :compIndex="rocketComps.current" :compType="compType" :durationTime="durationTime"  :stateDashboard='stateDashboardOption'/>
     <ToolNav :rocketGlobal="rocketGlobal" :rocketComps="rocketComps"/>
     <div class="dashboard-container clear">
       <DashboardItem
@@ -96,6 +96,8 @@ export default class Dashboard extends Vue {
     }
     this.handleOption();
     this.SET_EVENTS([this.handleRefresh]);
+
+    console.log(this.rocketComps, 'kevinkang---')
   }
   // private beforeDestroy() {
   //   this.$store.unregisterModule('rocketDashboard');


### PR DESCRIPTION
when tab is global type and you click select  service/endpoint/instance. the page has nothing change. It's confused for user.

so disabled the select item when page on global/service/endpoint level tab page.