### PR TITLE
Use URL parameters to visit specified trace

### DIFF
--- a/src/views/components/trace/trace-search.vue
+++ b/src/views/components/trace/trace-search.vue
@@ -95,12 +95,19 @@
     @Prop({default: {label: 'All', key: ''}})
     private service!: Option;
     private instance: Option = {label: 'All', key: ''};
-    private endpointName: string = localStorage.getItem('endpointName') || '';
-    private traceId: string = localStorage.getItem('traceId') || '';
+    private endpointName: string = this.getUrlKey('endpointname') || localStorage.getItem('endpointName') || '';
+    private traceId: string = this.getUrlKey('traceid') || localStorage.getItem('traceId') || '';
     private traceState: Option = {label: 'All', key: 'ALL'};
     @Prop({default: false, type: Boolean})
     private inTopo!: boolean;
 
+    private getUrlKey(name : any) {
+      const regex:RegExp = new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)');
+      return (
+      decodeURIComponent((regex.exec(location.href)! || [, ''])[1].replace(/\+/g, '%20')) || null
+      );
+    }
+  
     private dateFormat = (date: Date, step: string) => {
       const year = date.getFullYear();
       const monthTemp = date.getMonth() + 1;

--- a/src/views/components/trace/trace-search.vue
+++ b/src/views/components/trace/trace-search.vue
@@ -236,10 +236,8 @@
     }
 
     private created() {
-      const endpoint: any = this.$route.query.endpointname || this.endpointName;
-      const traceid: any = this.$route.query.traceid || this.traceId;
-      this.endpointName = endpoint;
-      this.traceId = traceid;
+      this.endpointName = this.$route.query.endpointname? this.$route.query.endpointname.toString() : this.endpointName;
+      this.traceId = this.$route.query.traceid? this.$route.query.traceid.toString() : this.traceId;
       this.time = [this.rocketbotGlobal.durationRow.start, this.rocketbotGlobal.durationRow.end];
     }
 

--- a/src/views/components/trace/trace-search.vue
+++ b/src/views/components/trace/trace-search.vue
@@ -95,18 +95,11 @@
     @Prop({default: {label: 'All', key: ''}})
     private service!: Option;
     private instance: Option = {label: 'All', key: ''};
-    private endpointName: string = this.getUrlKey('endpointname') || localStorage.getItem('endpointName') || '';
-    private traceId: string = this.getUrlKey('traceid') || localStorage.getItem('traceId') || '';
+    private endpointName: string = localStorage.getItem('endpointName') || '';
+    private traceId: string = localStorage.getItem('traceId') || '';
     private traceState: Option = {label: 'All', key: 'ALL'};
     @Prop({default: false, type: Boolean})
     private inTopo!: boolean;
-
-    private getUrlKey(name : any) {
-      const regex:RegExp = new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)');
-      return (
-      decodeURIComponent((regex.exec(location.href)! || [, ''])[1].replace(/\+/g, '%20')) || null
-      );
-    }
   
     private dateFormat = (date: Date, step: string) => {
       const year = date.getFullYear();
@@ -243,6 +236,10 @@
     }
 
     private created() {
+      const endpoint: any = this.$route.query.endpointname || this.endpointName;
+      const traceid: any = this.$route.query.traceid || this.traceId;
+      this.endpointName = endpoint;
+      this.traceId = traceid;
       this.time = [this.rocketbotGlobal.durationRow.start, this.rocketbotGlobal.durationRow.end];
     }
 


### PR DESCRIPTION
People want to use the trace URL parameters to visit the specified trace information instead of using Search button. It is very useful for some tools to use hyperlink to jump to skywalking trace page via endpointname and trace ID. This update is for URL parameters to visite specified trace.
example:
http://localhost:8880/trace?endpointname=runtest&traceid=2.30.15753618423830000