### PR TITLE
update event-bus type

### DIFF
--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -1,6 +1,7 @@
-import Vue from 'vue';
+import Vue, { VueConstructor  } from 'vue';
 
 type VueComponentVM = Vue & { _uid: string; };
+
 
 interface Handles {
   [key: string]: any[];
@@ -11,14 +12,14 @@ export class EventBus {
   private readonly eventMapUid: any;
   private handles!: Handles;
 
-  constructor(vue: Vue) {
+  constructor(vue: VueConstructor) {
     if (!this.handles) {
       Object.defineProperty(this, 'handles', {
         value: {},
         enumerable: false,
       });
     }
-    this.Vue = vue;
+    this.Vue = Vue;
     // _uid and event name map
     this.eventMapUid = {};
   }
@@ -62,6 +63,17 @@ export class EventBus {
     delete this.handles[eventName];
   }
 
+  /**
+   * eventBus.$offVmEvent.
+   * @param uid uid of VueComponentVM
+   */
+  public $offVmEvent(uid: string) {
+    const currentEvents = this.eventMapUid[uid] || [];
+    currentEvents.forEach((event: any) => {
+      this.$off(event);
+    });
+  }
+
   private setEventMapUid(uid: string, eventName: string) {
     if (!this.eventMapUid[uid]) {
       this.eventMapUid[uid] = [];
@@ -69,24 +81,17 @@ export class EventBus {
     // Push the name of each _uid subscription to the array to which the respective uid belongs.
     this.eventMapUid[uid].push(eventName);
   }
-
-  private $offVmEvent(uid: string) {
-    const currentEvents = this.eventMapUid[uid] || [];
-    currentEvents.forEach((event: any) => {
-      this.$off(event);
-    });
-  }
 }
 
 const $EventBus = {
-  install: (vue: any) => {
+  install: (vue: VueConstructor) => {
     vue.prototype.$eventBus = new EventBus(vue);
     vue.mixin({
       deactivated() {
-        this.$eventBus.$offVmEvent(this._uid);
+        (this as VueComponentVM).$eventBus.$offVmEvent((this as VueComponentVM)._uid);
       },
       beforeDestroy() {
-        this.$eventBus.$offVmEvent(this._uid);
+        (this as VueComponentVM).$eventBus.$offVmEvent((this as VueComponentVM)._uid);
       },
     });
   },

--- a/src/types/vue.d.ts
+++ b/src/types/vue.d.ts
@@ -1,7 +1,8 @@
 import Vue from 'vue';
+import { EventBus } from '@/event-bus';
 
 declare module 'vue/types/vue' {
   interface Vue {
-    $eventBus: any;
+    $eventBus: EventBus;
   }
 }


### PR DESCRIPTION
something about the commits:

- In *.vue files, `this.$evnentBus`  is `any` type.
- Vue.js plugin should expose an install method. The method will be called with the Vue constructor as the first argument.not Vue type. [check Vue documentation](https://vuejs.org/v2/guide/plugins.html#Writing-a-Plugin).but `EventBus.install` first argument is Vue type.
- the `private` method `$offVmEvent` is called from outside,
```ts
vue.mixin({
      deactivated() {
        // private method is called here
        this.$eventBus.$offVmEvent(this._uid);
      },
      beforeDestroy() {
        this.$eventBus.$offVmEvent(this._uid);
      },
    });
```
