### PR TITLE
Bug fix: trace table incomplete timestamp display

### DIFF
--- a/src/views/components/trace/trace-chart-table/trace-container.vue
+++ b/src/views/components/trace/trace-chart-table/trace-container.vue
@@ -21,7 +21,7 @@
         <div class="method">
           Method
         </div>
-        <div class="start-time">
+        <div class="start-time" style="width: 200px;">
           Start Time
         </div>
         <div class="gap">

--- a/src/views/components/trace/trace-chart-table/trace-container.vue
+++ b/src/views/components/trace/trace-chart-table/trace-container.vue
@@ -21,7 +21,7 @@
         <div class="method">
           Method
         </div>
-        <div class="start-time" style="width: 200px;">
+        <div class="start-time" lang="scss" style="width: 200px;">
           Start Time
         </div>
         <div class="gap">

--- a/src/views/components/trace/trace-chart-table/trace-item.vue
+++ b/src/views/components/trace/trace-chart-table/trace-item.vue
@@ -26,7 +26,7 @@
             {{data.endpointName}}
           </span>
         </div>
-        <div class="start-time">
+        <div class="start-time" style="width: 200px;">
           {{data.startTime | dateformat}}
         </div>
         <div class="gap">

--- a/src/views/components/trace/trace-chart-table/trace-item.vue
+++ b/src/views/components/trace/trace-chart-table/trace-item.vue
@@ -26,7 +26,7 @@
             {{data.endpointName}}
           </span>
         </div>
-        <div class="start-time" style="width: 200px;">
+        <div class="start-time" lang="scss" style="width: 200px;">
           {{data.startTime | dateformat}}
         </div>
         <div class="gap">


### PR DESCRIPTION
Bug fix: trace table incomplete timestamp display
链路跟踪每个span时间戳显示不全，且无其他方式可以正常显示，且表格宽度无法调整