### PR TITLE
Fix: refresh detect point data

### DIFF
--- a/src/store/modules/topology/index.ts
+++ b/src/store/modules/topology/index.ts
@@ -56,6 +56,7 @@ export interface State {
   detectPoints: string[];
   selectedServiceCall: Call | null;
   currentNode: any;
+  currentLink: any;
   current: Option;
   mode: boolean;
   getResponseTimeTrend: number[];
@@ -83,6 +84,7 @@ const initState: State = {
   _calls: [],
   _nodes: [],
   currentNode: {},
+  currentLink: {},
   current: {
     key: 'default',
     label: 'default',
@@ -120,6 +122,9 @@ const mutations = {
   },
   [types.SET_NODE](state: State, data: any) {
     state.currentNode = data;
+  },
+  [types.SET_LINK](state: State, data: any) {
+    state.currentLink = data;
   },
   [types.SET_TOPO](state: State, data: any) {
     state.calls = data.calls;

--- a/src/store/modules/topology/index.ts
+++ b/src/store/modules/topology/index.ts
@@ -240,6 +240,9 @@ const actions: ActionTree<State, any> = {
         duration: params.duration,
       })
       .then((res: AxiosResponse) => {
+        if (!res.data.data) {
+          return;
+        }
         context.commit('SET_TOPO_RELATION', res.data.data);
         context.commit(types.SET_SELECTED_CALL, params);
       });
@@ -249,6 +252,9 @@ const actions: ActionTree<State, any> = {
       .query('queryTopoClientInfo')
       .params(params)
       .then((res: AxiosResponse) => {
+        if (!res.data.data) {
+          return;
+        }
         context.commit('SET_TOPO_RELATION', res.data.data);
         context.commit(types.SET_SELECTED_CALL, params);
       });

--- a/src/store/mutation-types.ts
+++ b/src/store/mutation-types.ts
@@ -82,6 +82,7 @@ export const SET_HONEYCOMB_NODE = 'SET_HONEYCOMB_NODE';
 export const SET_SHOW_DIALOG = 'SET_SHOW_DIALOG';
 export const SET_INSTANCE_DEPENDENCY = 'SET_INSTANCE_DEPENDENCY';
 export const SET_TOPO_COPY = 'SET_TOPO_COPY';
+export const SET_LINK = 'SET_LINK';
 
 // comparison
 export const SET_CHARTVAL = 'SET_CHARTVAL';

--- a/src/views/components/topology/chart/topo.vue
+++ b/src/views/components/topology/chart/topo.vue
@@ -76,6 +76,7 @@ limitations under the License. -->
         event.stopPropagation();
         event.preventDefault();
         this.$store.commit('rocketTopo/SET_NODE', {});
+        this.$store.commit('rocketTopo/SET_LINK', {});
         this.$store.dispatch('rocketTopo/CLEAR_TOPO_INFO');
         this.tool.attr('style', 'display: none');
       });
@@ -110,10 +111,12 @@ limitations under the License. -->
         const {x, y, vx, vy, fx, fy, index, ...rest} = d;
         this.$store.dispatch('rocketTopo/CLEAR_TOPO_INFO');
         this.$store.commit('rocketTopo/SET_NODE', rest);
+        this.$store.commit('rocketTopo/SET_LINK', {});
       },
       handleLinkClick(d) {
         event.stopPropagation();
         this.$store.commit('rocketTopo/SET_NODE', {});
+        this.$store.commit('rocketTopo/SET_LINK', d);
         this.$store.dispatch('rocketTopo/CLEAR_TOPO_INFO');
         this.$store.commit('rocketTopo/SET_MODE', d.detectPoints);
         this.$store.dispatch(this.$store.state.rocketTopo.mode ? 'rocketTopo/GET_TOPO_SERVICE_INFO' :

--- a/src/views/components/topology/topo-aside.vue
+++ b/src/views/components/topology/topo-aside.vue
@@ -105,9 +105,19 @@ limitations under the License. -->
       this.drawerMainBodyHeight = `${document.body.clientHeight - 50}px`;
     }
 
+    private beforeMount() {
+      this.SET_EVENTS([this.handleRefresh]);
+    }
+
     private created() {
-      this.SET_EVENTS([]);
       this.SET_COMPS_TREE(this.initState.tree);
+    }
+
+    private handleRefresh() {
+      this.$store.dispatch(
+        this.stateTopo.mode ? 'rocketTopo/GET_TOPO_SERVICE_INFO' : 'rocketTopo/GET_TOPO_CLIENT_INFO',
+        { ...this.stateTopo.currentLink, duration: this.durationTime },
+      );
     }
 
     private mounted() {
@@ -119,6 +129,7 @@ limitations under the License. -->
       window.removeEventListener('resize', this.resize);
       this.CLEAR_TOPO_INFO();
       this.CLEAR_TOPO();
+      this.SET_EVENTS([]);
     }
 
     get types() {

--- a/src/views/containers/topology/topology.vue
+++ b/src/views/containers/topology/topology.vue
@@ -59,7 +59,6 @@ limitations under the License. -->
   export default class Topology extends Vue {
     @State('rocketTopo') private stateTopo!: topoState;
     @State('rocketOption') private stateDashboardOption!: any;
-    @Mutation('SET_EVENTS') private SET_EVENTS: any;
     @Action('rocketTopo/CLEAR_TOPO') private CLEAR_TOPO: any;
     @Action('rocketTopo/CLEAR_TOPO_INFO') private CLEAR_TOPO_INFO: any;
     @Getter('durationTime') private durationTime: any;


### PR DESCRIPTION
Fixes https://github.com/apache/skywalking-rocketbot-ui/issues/279 . Refresh detect point data when we update calendar.

**screenshots**

![屏幕快照 2020-04-14 下午6 35 16](https://user-images.githubusercontent.com/20871783/79215813-bc65f900-7e7e-11ea-86b0-7e0bace68f7f.png)
![屏幕快照 2020-04-14 下午6 35 30](https://user-images.githubusercontent.com/20871783/79215821-bec85300-7e7e-11ea-8732-46274a9f0156.png)
