### PR TITLE
Fix wrong indentations in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,7 +30,7 @@ github:
     merge:   false
     rebase:  false
 
-  notifications:
-    commits:      notifications@skywalking.apache.org
-    issues:       notifications@skywalking.apache.org
-    pullrequests: notifications@skywalking.apache.org
+notifications:
+  commits:      notifications@skywalking.apache.org
+  issues:       notifications@skywalking.apache.org
+  pullrequests: notifications@skywalking.apache.org


### PR DESCRIPTION
According to the infra team, the indentations are wrong, which causes the notifications are still sent to the dev@ ML