### PR TITLE
fix: Set current service for topology

### DIFF
--- a/src/views/containers/topology/instance/index.vue
+++ b/src/views/containers/topology/instance/index.vue
@@ -93,6 +93,7 @@ limitations under the License. -->
     @Action('GET_SERVICE_INSTANCES') private GET_SERVICE_INSTANCES: any;
     @Action('MIXHANDLE_CHANGE_GROUP_WITH_CURRENT') private MIXHANDLE_CHANGE_GROUP_WITH_CURRENT: any;
     @Mutation('SET_EDIT') private SET_EDIT: any;
+    @Mutation('SET_CURRENT_SERVICE') private SET_CURRENT_SERVICE: any;
     @Prop() private current!: { key: number | string; label: number | string };
     @Prop() private instanceComps: any;
     @Prop() private updateObjects!: string;
@@ -102,6 +103,7 @@ limitations under the License. -->
     }
 
     private beforeMount() {
+      this.SET_CURRENT_SERVICE(this.current);
       this.MIXHANDLE_CHANGE_GROUP_WITH_CURRENT({ index: 0, current: 3 });
       this.GET_SERVICE_INSTANCES({ duration: this.durationTime, serviceId: this.current.key }).then(() => {
         this.selectInstance(this.stateDashboardOption.instances[0]);


### PR DESCRIPTION
Refer to https://github.com/apache/skywalking-rocketbot-ui/issues/358. Fixes the current service for topology instance page.

Screenshot
![test](https://user-images.githubusercontent.com/20871783/94883005-23fb1980-049c-11eb-999f-6447d465842f.jpeg)

signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
