### PR TITLE
Removed "Les Miserables" from radial chart in topology.

### DIFF
--- a/src/views/components/topology/radial.vue
+++ b/src/views/components/topology/radial.vue
@@ -84,7 +84,7 @@ limitations under the License. -->
             {
               top: '20%',
               height: '60%',
-              name: 'Les Miserables',
+              name: this.$t('service'),
               type: 'graph',
               layout: 'circular',
               circular: {


### PR DESCRIPTION
A small fix/tweak. I'm assuming, that "Service" is a valid label in this place.