### PR TITLE
fix: trace instance selector

### DIFF
--- a/src/store/modules/dashboard/dashboard-option.ts
+++ b/src/store/modules/dashboard/dashboard-option.ts
@@ -182,9 +182,22 @@ const actions: ActionTree<State, any> = {
           .then(() => context.dispatch('GET_SERVICE_INSTANCES', { duration: params.duration }));
       case 'database':
         return context.dispatch('GET_DATABASES', { duration: params.duration });
+      case 'browser':
+        return context
+          .dispatch('GET_BROWSER_SERVICES', { duration: params.duration, keyword: params.keywordServiceName })
+          .then(() => context.dispatch('GET_SERVICE_ENDPOINTS', {}))
+          .then(() => context.dispatch('GET_SERVICE_INSTANCES', { duration: params.duration }));
       default:
         break;
     }
+  },
+  GET_BROWSER_SERVICES(context: { commit: Commit }, params: { duration: any }) {
+    return graph
+      .query('queryBrowserServices')
+      .params(params)
+      .then((res: AxiosResponse) => {
+        context.commit(types.SET_SERVICES, res.data.data.services);
+      });
   },
   GET_ITEM_ENDPOINTS(context, params) {
     return graph

--- a/src/store/modules/trace/index.ts
+++ b/src/store/modules/trace/index.ts
@@ -52,9 +52,6 @@ const initState: State = {
   },
 };
 
-// getters
-const getters = {};
-
 // mutations
 const mutations: MutationTree<State> = {
   [types.SET_SERVICES](state: State, data: Option[]): void {
@@ -157,7 +154,6 @@ const actions: ActionTree<State, any> = {
 export default {
   namespaced: true,
   state: initState,
-  getters,
   actions,
   mutations,
 };

--- a/src/views/components/trace/trace-search.vue
+++ b/src/views/components/trace/trace-search.vue
@@ -130,6 +130,7 @@ limitations under the License. -->
     @Action('rocketTrace/SET_TRACE_FORM') private SET_TRACE_FORM: any;
     @Mutation('rocketTrace/SET_TRACE_FORM_ITEM')
     private SET_TRACE_FORM_ITEM: any;
+    @Mutation('rocketTrace/SET_INSTANCES') private SET_INSTANCES: any;
     private service: Option = { label: 'All', key: '' };
     private time!: Date[];
     private status: boolean = true;
@@ -217,6 +218,7 @@ limitations under the License. -->
       this.instance = { label: 'All', key: '' };
       this.service = i;
       if (i.key === '') {
+        this.SET_INSTANCES([]);
         return;
       }
       this.GET_INSTANCES({ duration: this.durationTime, serviceId: i.key });


### PR DESCRIPTION
Fixes https://github.com/apache/skywalking-rocketbot-ui/issues/356
Fixes browser dashboard selectors

Screenshot
when select "all" again in the service dropdown after selecting any service,  no instances in the instance dropdown
![test](https://user-images.githubusercontent.com/20871783/101017027-822fa000-35a4-11eb-98e9-437f78544202.png)

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
