### PR TITLE
fix: update utc and sort group

### DIFF
--- a/src/components/rk-footer.vue
+++ b/src/components/rk-footer.vue
@@ -36,8 +36,8 @@ limitations under the License. -->
     @State('rocketbot') private rocketbotGlobal: any;
     @Action('SET_DURATION') private SET_DURATION: any;
     @Action('SET_UTC') private SET_UTC: any;
-    private lang: any = '';
-    private utc: any = window.localStorage.getItem('utc') || -(new Date().getTimezoneOffset() / 60);
+    private lang: string | null = '';
+    private utc: number = 0;
     @Watch('utc')
     private onUtcUpdate() {
       if (this.utc < -12) {
@@ -46,7 +46,7 @@ limitations under the License. -->
       if (this.utc > 14) {
         this.utc = 14;
       }
-      if (this.utc === '') {
+      if (!this.utc) {
         this.utc = 0;
       }
       this.SET_UTC(this.utc);
@@ -64,6 +64,7 @@ limitations under the License. -->
       }
     }
     private beforeMount() {
+      this.utc = Number(window.localStorage.getItem('utc') || -(new Date().getTimezoneOffset() / 60));
       this.lang = window.localStorage.getItem('lang');
     }
   }

--- a/src/views/components/topology/topo-services.vue
+++ b/src/views/components/topology/topo-services.vue
@@ -57,7 +57,7 @@ limitations under the License. -->
             }
           }
           this.groups = [
-            ...groups.map((g) => {
+            ...groups.sort().map((g) => {
               return {
                 key: g,
                 label: g,


### PR DESCRIPTION
Fixes the utc value in the footer and sort group names in the topology.

Screenshots
![topo](https://user-images.githubusercontent.com/20871783/103626590-5fafee80-4f77-11eb-8629-09c0e3248f55.png)
Enter the dashboard without utc local storage
![test](https://user-images.githubusercontent.com/20871783/103626595-6179b200-4f77-11eb-9c09-c16e75f65117.png)

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
