### PR TITLE
fix: support `=` in the tag value in the trace query page.

### DIFF
--- a/src/views/components/trace/trace-search.vue
+++ b/src/views/components/trace/trace-search.vue
@@ -274,7 +274,7 @@ limitations under the License. -->
 
           return {
             key,
-            value: item.split(key + '=')[1],
+            value: item.substring(item.indexOf('=') + 1, item.length),
           };
         });
         temp.tags = tagsMap;

--- a/src/views/components/trace/trace-search.vue
+++ b/src/views/components/trace/trace-search.vue
@@ -270,10 +270,11 @@ limitations under the License. -->
       }
       if (this.tagsList.length) {
         const tagsMap = this.tagsList.map((item: string) => {
-          const t = item.split('=');
+          const key = item.substring(0, item.indexOf('='));
+
           return {
-            key: t[0],
-            value: t[1],
+            key,
+            value: item.split(key + '=')[1],
           };
         });
         temp.tags = tagsMap;

--- a/src/views/containers/topology/trace/index.vue
+++ b/src/views/containers/topology/trace/index.vue
@@ -38,8 +38,6 @@ limitations under the License. -->
   })
   export default class WindowTrace extends Vue {
     @State('rocketTrace') private stateTrace!: any;
-    @Action('rocketTrace/GET_TRACELIST') private GET_TRACELIST: any;
-    @Action('rocketTrace/GET_TRACE_SPANS') private GET_TRACE_SPANS: any;
     @Prop() private current!: Option;
   }
 </script>

--- a/src/views/containers/trace.vue
+++ b/src/views/containers/trace.vue
@@ -40,8 +40,6 @@ limitations under the License. -->
   export default class Trace extends Vue {
     @State('rocketTrace') private stateTrace!: any;
     @Mutation('SET_EVENTS') private SET_EVENTS: any;
-    @Action('rocketTrace/GET_TRACELIST') private GET_TRACELIST: any;
-    @Action('rocketTrace/GET_TRACE_SPANS') private GET_TRACE_SPANS: any;
 
     @Prop({ default: () => ({ label: 'All', key: '' }) })
     private service!: Option;


### PR DESCRIPTION
Use first = to separate key and value for tags in trace. Fix https://github.com/apache/skywalking/issues/6160

Screenshot
![test](https://user-images.githubusercontent.com/20871783/104086849-2a1c4580-5296-11eb-8f91-2aa8fcea22bc.png)


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
