### PR TITLE
fix the time display error of log query.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,10 +46,8 @@ Vue.use(VModal, { dialog: true });
 Vue.directive('clickout', clickout);
 Vue.directive('tooltip', tooltip);
 
-Vue.filter(
-  'dateformat',
-  (dataStr: any, pattern: string = 'YYYY-MM-DD HH:mm:ss') =>
-    moment(dataStr).format(pattern),
+Vue.filter('dateformat', (dataStr: any, pattern: string = 'YYYY-MM-DD HH:mm:ss') =>
+  moment(Number.parseInt(dataStr)).format(pattern),
 );
 
 const savedLanguage = window.localStorage.getItem('lang');


### PR DESCRIPTION
Fix the time display error of log query.
**Before**:
`Vue.filter(
  'dateformat',
  (dataStr: any, pattern: string = 'YYYY-MM-DD HH:mm:ss') =>
  moment(dataStr).format(pattern),`
its potential problem is that it is not converted to a digital timestamp,so I added `Number.parseInt(dataStr)` to it to solve the conversion problem.
**After modification**
`Vue.filter('dateformat', (dataStr: any, pattern: string = 'YYYY-MM-DD HH:mm:ss') =>
  moment(Number.parseInt(dataStr)).format(pattern),
);`