### PR TITLE
fix: clear trace id by clear search conditions

### DIFF
--- a/src/store/modules/log/index.ts
+++ b/src/store/modules/log/index.ts
@@ -58,6 +58,7 @@ const logState: State = {
   category: { label: 'All', key: 'ALL' },
   loading: false,
   conditions: {
+    traceId: localStorage.getItem('logTraceId') || '',
     keywordsOfContent: localStorage.getItem('logKeywordsOfContent')
       ? JSON.parse(localStorage.getItem('logKeywordsOfContent') || '')
       : [],
@@ -95,10 +96,13 @@ const mutations: MutationTree<State> = {
     state.supportQueryLogsByKeywords = isSupport;
   },
   [types.CLEAR_LOG_CONDITIONS](state: State) {
-    state.conditions = {};
+    state.conditions = {
+      date: state.conditions.date,
+    };
     localStorage.removeItem('logKeywordsOfContent');
     localStorage.removeItem('logExcludingKeywordsOfContent');
     localStorage.removeItem('logTags');
+    localStorage.removeItem('logTraceId');
   },
 };
 

--- a/src/views/components/log/log-conditions.vue
+++ b/src/views/components/log/log-conditions.vue
@@ -19,6 +19,7 @@ limitations under the License. -->
         <input
           type="text"
           class="rk-trace-search-input dib"
+          v-model="traceId"
           @change="changeConditions($event, LogConditionsOpt.TraceID)"
         />
       </div>
@@ -132,6 +133,7 @@ limitations under the License. -->
     private tagsList: string[] = [];
     private tags: string = '';
     private searchTime: Date[] = [];
+    private traceId: string = '';
     private LogConditionsOpt = {
       TraceID: 'traceId',
       Tags: 'tags',
@@ -144,6 +146,7 @@ limitations under the License. -->
       this.searchTime = [this.rocketbotGlobal.durationRow.start, this.rocketbotGlobal.durationRow.end];
       (this.tagsList = localStorage.getItem('logTags') ? JSON.parse(localStorage.getItem('logTags') || '') : []),
         this.updateTags();
+      this.traceId = localStorage.getItem('logTraceId') || '';
     }
     private changeConditions(item: any, type: string) {
       item = {
@@ -151,6 +154,7 @@ limitations under the License. -->
         key: item.target.value,
       };
       this.SET_LOG_CONDITIONS(item);
+      localStorage.setItem('logTraceId', this.traceId);
     }
     private addLabels(event: KeyboardEvent, type: string) {
       if (event.keyCode !== 13) {
@@ -257,10 +261,13 @@ limitations under the License. -->
         step,
       };
     }
-    @Watch('rocketLog.conditions.tags')
+    @Watch('rocketLog.conditions')
     private clearTags() {
       if (!this.rocketLog.conditions.tags) {
         this.tagsList = [];
+      }
+      if (!this.rocketLog.conditions.traceId) {
+        this.traceId = '';
       }
     }
     @Watch('searchTime')


### PR DESCRIPTION
Fixes https://github.com/apache/skywalking/issues/6429. Clear trace id by clear search conditions

Screenshots
The following image is search logs by trace id.
![1](https://user-images.githubusercontent.com/20871783/109102351-a0500b00-7763-11eb-99da-c9fbf77746fa.png)
The following image is clear all of conditions, including trace id.
![2](https://user-images.githubusercontent.com/20871783/109102352-a1813800-7763-11eb-9760-9e7c1aed5757.png)

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
