### PR TITLE
feat: extend table chart

### DIFF
--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -201,6 +201,10 @@ const m = {
   keywordsOfContentLogTips: 'Current storage of SkyWalking OAP server does not support this.',
   instanceAttributes: 'Instance Attributes',
   value: 'Value',
+  tableHeader: 'Header Names',
+  tableValues: 'Table Values',
+  show: 'Show',
+  hide: 'Hide',
 };
 
 export default m;

--- a/src/assets/lang/zh.ts
+++ b/src/assets/lang/zh.ts
@@ -199,6 +199,10 @@ const m = {
   keywordsOfContentLogTips: 'SkyWalking OAP服务器的当前存储不支持此操作',
   instanceAttributes: '查看实例属性',
   value: '数值',
+  tableHeader: '表头名称',
+  tableValues: '表值',
+  show: '展示',
+  hide: '隐藏',
 };
 
 export default m;

--- a/src/views/components/dashboard/charts/chart-edit.vue
+++ b/src/views/components/dashboard/charts/chart-edit.vue
@@ -338,7 +338,6 @@ limitations under the License. -->
 
     private created() {
       this.itemConfig = this.item;
-      console.log(this.itemConfig);
       this.initConfig();
       if (!this.itemConfig.independentSelector || this.pageTypes.includes(this.type)) {
         return;

--- a/src/views/components/dashboard/charts/chart-table.vue
+++ b/src/views/components/dashboard/charts/chart-table.vue
@@ -15,21 +15,21 @@ limitations under the License. -->
 
 <template>
   <div class="rk-chart-table">
-    <table ref="chartTable">
-      <tr>
-        <th :style="`width: ${nameWidth}px`">
+    <div ref="chartTable">
+      <div class="row flex-h" :style="`width: ${nameWidth + initWidth}px`">
+        <div class="name" :style="`width: ${nameWidth}px`">
           {{ item.tableHeaderCol1 || $t('name') }}
-          <span class="r cp" ref="draggerName"><rk-icon icon="settings_ethernet"/></span>
-        </th>
-        <th class="value-col">
+          <i class="r cp" ref="draggerName"><rk-icon icon="settings_ethernet"/></i>
+        </div>
+        <div class="value-col" v-if="showTableValues">
           {{ item.tableHeaderCol2 || $t('value') }}
-        </th>
-      </tr>
-      <tr v-for="key in dataKeys" :key="key">
-        <td :style="`width: ${nameWidth}px`">{{ key }}</td>
-        <td class="value-col" v-show="item.showTableValues">{{ data[key][dataLength(data[key])] }}</td>
-      </tr>
-    </table>
+        </div>
+      </div>
+      <div class="row flex-h" v-for="key in dataKeys" :key="key" :style="`width: ${nameWidth + initWidth}px`">
+        <div :style="`width: ${nameWidth}px`">{{ key }}</div>
+        <div class="value-col" v-if="showTableValues">{{ data[key][dataLength(data[key])] }}</div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -43,19 +43,24 @@ limitations under the License. -->
     @Prop() private item: any;
 
     private nameWidth: number = 0;
-    // private initWidth: number = 0;
+    private initWidth: number = 0;
 
     private get dataKeys() {
       const keys = Object.keys(this.data || {}).filter((i: any) => Array.isArray(this.data[i]) && this.data[i].length);
       return keys;
     }
 
+    private get showTableValues() {
+      return this.item.showTableValues === 'true' || this.item.showTableValues === true ? true : false;
+    }
+
     private mounted() {
       const chartTable: any = this.$refs.chartTable;
-      this.nameWidth = chartTable.offsetWidth / 2;
-      // this.initWidth = chartTable.offsetWidth / 2;
+      const width = this.showTableValues ? chartTable.offsetWidth / 2 : chartTable.offsetWidth;
+      this.initWidth = this.showTableValues ? chartTable.offsetWidth / 2 : 0;
+      this.nameWidth = width - 5;
       const drag: any = this.$refs.draggerName;
-      drag.onmousedown = (event: any) => {
+      drag.onmousedown = (event: MouseEvent) => {
         const diffX = event.clientX;
         const copy = this.nameWidth;
         document.onmousemove = (documentEvent) => {
@@ -79,21 +84,30 @@ limitations under the License. -->
     height: 100%;
     width: 100%;
     overflow: auto;
-    table {
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
-      overflow: auto;
+    .name {
+      padding-left: 15px;
     }
-    tr {
-      border: 1px solid #ccc;
-    }
-    th,
-    td {
+    .row {
       border-left: 1px solid #ccc;
-      border-bottom: 1px solid #ccc;
-      text-align: center;
       height: 20px;
-      line-height: 20px;
+      div {
+        border-right: 1px solid #ccc;
+        text-align: center;
+        height: 20px;
+        line-height: 20px;
+        display: inline-block;
+      }
+      div:last-child {
+        border-bottom: 1px solid #ccc;
+      }
+      div:nth-last-child(2) {
+        border-bottom: 1px solid #ccc;
+      }
+    }
+    .row:first-child {
+      div {
+        border-top: 1px solid #ccc;
+      }
     }
     .value-col {
       width: 50%;

--- a/src/views/components/dashboard/charts/chart-table.vue
+++ b/src/views/components/dashboard/charts/chart-table.vue
@@ -15,14 +15,19 @@ limitations under the License. -->
 
 <template>
   <div class="rk-chart-table">
-    <table>
+    <table ref="chartTable">
       <tr>
-        <th>{{ item.tableHeaderCol1 || $t('name') }}</th>
-        <th>{{ item.tableHeaderCol2 || $t('value') }}</th>
+        <th :style="`width: ${nameWidth}px`">
+          {{ item.tableHeaderCol1 || $t('name') }}
+          <span class="r cp" ref="draggerName"><rk-icon icon="settings_ethernet"/></span>
+        </th>
+        <th class="value-col">
+          {{ item.tableHeaderCol2 || $t('value') }}
+        </th>
       </tr>
       <tr v-for="key in dataKeys" :key="key">
-        <td>{{ key }}</td>
-        <td v-show="item.showTableValues">{{ data[key][dataLength(data[key])] }}</td>
+        <td :style="`width: ${nameWidth}px`">{{ key }}</td>
+        <td class="value-col" v-show="item.showTableValues">{{ data[key][dataLength(data[key])] }}</td>
       </tr>
     </table>
   </div>
@@ -37,12 +42,34 @@ limitations under the License. -->
     @Prop() private data!: any;
     @Prop() private item: any;
 
+    private nameWidth: number = 0;
+    // private initWidth: number = 0;
+
     private get dataKeys() {
       const keys = Object.keys(this.data || {}).filter((i: any) => Array.isArray(this.data[i]) && this.data[i].length);
       return keys;
     }
 
-    private dataLength(param: any[]) {
+    private mounted() {
+      const chartTable: any = this.$refs.chartTable;
+      this.nameWidth = chartTable.offsetWidth / 2;
+      // this.initWidth = chartTable.offsetWidth / 2;
+      const drag: any = this.$refs.draggerName;
+      drag.onmousedown = (event: any) => {
+        const diffX = event.clientX;
+        const copy = this.nameWidth;
+        document.onmousemove = (documentEvent) => {
+          const moveX = documentEvent.clientX - diffX;
+          this.nameWidth = copy + moveX;
+        };
+        document.onmouseup = () => {
+          document.onmousemove = null;
+          document.onmouseup = null;
+        };
+      };
+    }
+
+    private dataLength(param: number[]) {
       return param.length - 1 || 0;
     }
   }
@@ -50,24 +77,26 @@ limitations under the License. -->
 <style lang="scss" scoped>
   .rk-chart-table {
     height: 100%;
+    width: 100%;
     overflow: auto;
     table {
-      width: 100%;
       border-top: 1px solid #ccc;
       border-right: 1px solid #ccc;
+      overflow: auto;
     }
     tr {
-      width: 100%;
       border: 1px solid #ccc;
     }
     th,
     td {
       border-left: 1px solid #ccc;
       border-bottom: 1px solid #ccc;
-      width: 50%;
       text-align: center;
       height: 20px;
       line-height: 20px;
+    }
+    .value-col {
+      width: 50%;
     }
   }
 </style>

--- a/src/views/components/dashboard/charts/chart-table.vue
+++ b/src/views/components/dashboard/charts/chart-table.vue
@@ -48,6 +48,8 @@ limitations under the License. -->
 </script>
 <style lang="scss" scoped>
   .rk-chart-table {
+    height: 100%;
+    overflow: auto;
     table {
       width: 100%;
       border-top: 1px solid #ccc;
@@ -63,6 +65,8 @@ limitations under the License. -->
       border-bottom: 1px solid #ccc;
       width: 50%;
       text-align: center;
+      height: 20px;
+      line-height: 20px;
     }
   }
 </style>

--- a/src/views/components/dashboard/charts/chart-table.vue
+++ b/src/views/components/dashboard/charts/chart-table.vue
@@ -17,12 +17,12 @@ limitations under the License. -->
   <div class="rk-chart-table">
     <table>
       <tr>
-        <th>{{ $t('name') }}</th>
-        <th>{{ $t('value') }}</th>
+        <th>{{ item.tableHeaderCol1 || $t('name') }}</th>
+        <th>{{ item.tableHeaderCol2 || $t('value') }}</th>
       </tr>
       <tr v-for="key in dataKeys" :key="key">
         <td>{{ key }}</td>
-        <td>{{ data[key][dataLength(data[key])] }}</td>
+        <td v-show="item.showTableValues">{{ data[key][dataLength(data[key])] }}</td>
       </tr>
     </table>
   </div>
@@ -35,6 +35,7 @@ limitations under the License. -->
   @Component
   export default class ChartTable extends Vue {
     @Prop() private data!: any;
+    @Prop() private item: any;
 
     private get dataKeys() {
       const keys = Object.keys(this.data || {}).filter((i: any) => Array.isArray(this.data[i]) && this.data[i].length);

--- a/src/views/components/dashboard/dashboard-comp.vue
+++ b/src/views/components/dashboard/dashboard-comp.vue
@@ -51,8 +51,8 @@ limitations under the License. -->
 </template>
 
 <script lang="ts">
-  import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
-  import { State, Mutation } from 'vuex-class';
+  import { Vue, Component, Prop } from 'vue-property-decorator';
+  import { Mutation } from 'vuex-class';
   import copy from '@/utils/copy';
 
   @Component

--- a/src/views/components/dashboard/dashboard-item.vue
+++ b/src/views/components/dashboard/dashboard-item.vue
@@ -28,7 +28,7 @@ limitations under the License. -->
       </span>
     </div>
     <div class="rk-dashboard-item-body">
-      <div style="height:100%;">
+      <div style="height:100%; width:100%">
         <component
           :is="rocketGlobal.edit ? 'ChartEdit' : itemConfig.chartType"
           ref="chart"

--- a/src/views/components/dashboard/dashboard-item.vue
+++ b/src/views/components/dashboard/dashboard-item.vue
@@ -26,6 +26,9 @@ limitations under the License. -->
           <use xlink:href="#lock"></use>
         </svg>
       </span>
+      <span v-show="!rocketGlobal.edit && itemConfig.chartType === 'ChartTable'" @click="copyTable">
+        <rk-icon class="r cp" icon="review-list" />
+      </span>
     </div>
     <div class="rk-dashboard-item-body">
       <div style="height:100%; width:100%">
@@ -72,6 +75,7 @@ limitations under the License. -->
   import { CalculationType } from './charts/constant';
   import { State as globalState } from '@/store/modules/global';
   import { State as optionState } from '@/store/modules/global/selectors';
+  import copy from '@/utils/copy';
 
   @Component({
     components: { ...charts },
@@ -311,6 +315,18 @@ limitations under the License. -->
       if (type === 'unit') {
         this.unit = value;
       }
+    }
+
+    private copyTable() {
+      const data: any = {};
+      const keys = Object.keys(this.chartSource || {}).filter(
+        (i: any) => Array.isArray(this.chartSource[i]) && this.chartSource[i].length,
+      );
+      for (const key of keys) {
+        const index = this.chartSource[key].length - 1 || 0;
+        data[key] = this.chartSource[key][index];
+      }
+      copy(JSON.stringify(data));
     }
 
     private deleteItem(index: number) {


### PR DESCRIPTION
Extends table chart, including style, zoom width, add config, and copy data.

Screenshots
![1](https://user-images.githubusercontent.com/20871783/113548702-95ba4880-9622-11eb-810b-266871adc1e0.png)
![2](https://user-images.githubusercontent.com/20871783/113548705-97840c00-9622-11eb-9ba9-78a07f5e5d78.png)
![3](https://user-images.githubusercontent.com/20871783/113548709-994dcf80-9622-11eb-9045-8fe857ffaea2.png)
![4](https://user-images.githubusercontent.com/20871783/113548730-a36fce00-9622-11eb-8516-6134e33d2787.png)
![5](https://user-images.githubusercontent.com/20871783/113548738-a66abe80-9622-11eb-9b5b-0ffdffaeadac.png)

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
