### PR TITLE
Add tooltip for dashboard component

### DIFF
--- a/src/views/components/dashboard/dashboard-item.vue
+++ b/src/views/components/dashboard/dashboard-item.vue
@@ -27,6 +27,7 @@ limitations under the License. -->
       <span v-show="!rocketGlobal.edit && itemConfig.chartType === 'ChartTable'" @click="copyTable">
         <rk-icon class="r cp" icon="review-list" />
       </span>
+      <rk-icon v-if="tips" class="r edit" icon="info_outline" v-tooltip:bottom="{ content: tips }" />
     </div>
     <div class="rk-dashboard-item-body" ref="chartBody">
       <div style="height:100%;width:100%">
@@ -102,6 +103,7 @@ limitations under the License. -->
     private dialogConfigVisible = false;
     private status = 'UNKNOWN';
     private title = 'Title';
+    private tips = '';
     private unit = '';
     private width = 3;
     private height = 300;
@@ -112,6 +114,7 @@ limitations under the License. -->
     private created() {
       this.status = this.item.metricType;
       this.title = this.item.title;
+      this.tips = this.item.tips;
       this.width = this.item.width;
       this.height = this.item.height;
       this.unit = this.item.unit;


### PR DESCRIPTION
<img width="537" alt="Screen Shot 2021-04-20 at 15 12 46" src="https://user-images.githubusercontent.com/15965696/115353480-1f554300-a1eb-11eb-8181-b14c5ca095ee.png">

This is a simple enhancement to support a tooltip in the UI template.