### PR TITLE
fix: update independentSelector in dashboard

### DIFF
--- a/src/views/components/dashboard/charts/chart-edit.vue
+++ b/src/views/components/dashboard/charts/chart-edit.vue
@@ -433,6 +433,7 @@ limitations under the License. -->
         } else {
           this.EDIT_COMP_CONFIG({ index: this.index, values: { [params.type]: this.itemConfig[params.type] } });
         }
+        return;
       }
       if (params.type === 'aggregation' && ['milliseconds', 'seconds'].includes(this.itemConfig.aggregation)) {
         this.updateAggregation(params);

--- a/src/views/components/dashboard/charts/constant.ts
+++ b/src/views/components/dashboard/charts/constant.ts
@@ -29,8 +29,8 @@ export const BrowserEntityType = [
 ];
 
 export const IndependentType = [
-  { key: 'true', label: 'Self selectors' },
-  { key: 'false', label: 'Common selectors' },
+  { key: true, label: 'Self selectors' },
+  { key: false, label: 'Common selectors' },
 ];
 
 export enum MetricsType {

--- a/src/views/components/trace/trace-search.vue
+++ b/src/views/components/trace/trace-search.vue
@@ -221,10 +221,8 @@ limitations under the License. -->
         temp.traceId = this.traceId;
       }
       localStorage.setItem('traceId', this.traceId);
-      
       temp.tags = this.tagsMap;
       localStorage.setItem('traceTags', JSON.stringify(this.tagsList));
-      
       this.SET_TRACE_FORM(temp);
       this.$eventBus.$emit('SET_LOADING_TRUE', () => {
         this.GET_TRACELIST().then(() => {


### PR DESCRIPTION
Fixes configuration type in dashboard. Reference https://github.com/apache/skywalking/issues/6878

Test
`
[{"name":"APM","type":"service","children":[{"name":"Global","children":[{"width":"3","title":"Services Load","height":"300","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_cpm","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":false,"unit":"CPM - calls per minute","maxItemNum":"10","sortOrder":"DES","aggregation":"+"},{"width":3,"title":"Slow Services","height":"300","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_resp_time","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":false,"unit":"ms","maxItemNum":"10","sortOrder":"DES"},{"width":3,"title":"Un-Health Services (Apdex)","height":"300","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_apdex","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":false,"aggregation":"/","aggregationNum":"10000","sortOrder":"ASC","maxItemNum":"10"},{"width":3,"title":"Slow Endpoints","height":"300","entityType":"Endpoint","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"endpoint_avg","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":false,"unit":"ms","maxItemNum":"10"},{"width":"6","title":"Global Response Latency","height":"280","entityType":"All","independentSelector":false,"metricType":"LABELED_VALUE","metricName":"all_percentile","queryMetricType":"readLabeledMetricsValues","chartType":"ChartLine","metricLabels":"P50, P75, P90, P95, P99","labelsIndex":"0, 1, 2, 3, 4","unit":"percentile in ms","maxItemNum":"10"},{"width":"6","title":"Global Heatmap","height":"280","entityType":"All","independentSelector":false,"metricType":"HEATMAP","unit":"ms","queryMetricType":"readHeatMap","chartType":"ChartHeatmap","metricName":"all_heatmap","maxItemNum":"10"}]},{"name":"Service","children":[{"width":3,"title":"Service Apdex","height":"200","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_apdex","queryMetricType":"readMetricsValue","chartType":"ChartNum","aggregation":"/","aggregationNum":"10000","maxItemNum":"10"},{"width":3,"title":"Service Avg Response Time","height":"200","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_resp_time","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"ms","maxItemNum":"10"},{"width":3,"title":"Successful Rate","height":"200","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_sla","queryMetricType":"readMetricsValue","chartType":"ChartNum","unit":"%","aggregation":"/","aggregationNum":"100","maxItemNum":"10"},{"width":3,"title":"Service Load","height":"200","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_cpm","queryMetricType":"readMetricsValue","chartType":"ChartNum","unit":"CPM - calls per minute","maxItemNum":"10"},{"width":3,"title":"Service Apdex","height":"200","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_apdex","queryMetricType":"readMetricsValues","chartType":"ChartLine","aggregation":"/","aggregationNum":"10000","maxItemNum":"10"},{"width":3,"title":"Service Response Time Percentile","height":"200","entityType":"Service","independentSelector":false,"metricType":"LABELED_VALUE","metricName":"service_percentile","queryMetricType":"readLabeledMetricsValues","chartType":"ChartLine","unit":"ms","metricLabels":"P50, P75, P90, P95, P99","labelsIndex":"0, 1, 2, 3, 4","maxItemNum":"10"},{"width":3,"title":"Successful Rate","height":"200","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_sla","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"%","aggregation":"/","aggregationNum":"100","maxItemNum":"10"},{"width":3,"title":"Service Load","height":"200","entityType":"Service","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_cpm","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"CPM - calls per minute","maxItemNum":"10"},{"width":"4","title":"Service Instances Load","height":"280","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_instance_cpm","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":true,"unit":"CPM - calls per minute","maxItemNum":"10"},{"width":"4","title":"Slow Service Instance","height":"280","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_instance_resp_time","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":true,"unit":"ms","maxItemNum":"10"},{"width":"4","title":"Service Instance Successful Rate","height":"280","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_instance_sla","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":true,"unit":"%","aggregation":"/","aggregationNum":"100","sortOrder":"ASC","maxItemNum":"10"}]},{"name":"Instance","children":[{"width":"4","title":"Service Instance Load","height":"150","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_instance_cpm","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"CPM - calls per minute"},{"width":"4","title":"Service Instance Successful Rate","height":"150","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_instance_sla","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"%","aggregation":"/","aggregationNum":"100"},{"width":"4","title":"Service Instance Latency","height":"150","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"service_instance_resp_time","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"ms"},{"width":3,"title":"JVM CPU (Java Service)","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"instance_jvm_cpu","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"%","aggregation":"+","aggregationNum":""},{"width":3,"title":"JVM Memory (Java Service)","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"instance_jvm_memory_heap, instance_jvm_memory_heap_max,instance_jvm_memory_noheap, instance_jvm_memory_noheap_max","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"MB","aggregation":"/","aggregationNum":"1048576"},{"width":3,"title":"JVM GC Time","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"instance_jvm_young_gc_time, instance_jvm_old_gc_time","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"ms"},{"width":3,"title":"JVM GC Count","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","queryMetricType":"readMetricsValues","chartType":"ChartBar","metricName":"instance_jvm_young_gc_count, instance_jvm_old_gc_count"},{"width":3,"title":"JVM Thread Count (Java Service)","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","queryMetricType":"readMetricsValues","chartType":"ChartLine","metricName":"instance_jvm_thread_live_count, instance_jvm_thread_daemon_count, instance_jvm_thread_peak_count"},{"width":3,"title":"CLR CPU  (.NET Service)","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"instance_clr_cpu","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"%"},{"width":3,"title":"CLR GC (.NET Service)","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"instance_clr_gen0_collect_count, instance_clr_gen1_collect_count, instance_clr_gen2_collect_count","queryMetricType":"readMetricsValues","chartType":"ChartBar"},{"width":3,"title":"CLR Heap Memory (.NET Service)","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"instance_clr_heap_memory","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"MB","aggregation":"/","aggregationNum":"1048576"},{"width":3,"title":"CLR Thread (.NET Service)","height":"250","entityType":"ServiceInstance","independentSelector":false,"metricType":"REGULAR_VALUE","queryMetricType":"readMetricsValues","chartType":"ChartLine","metricName":"instance_clr_available_completion_port_threads,instance_clr_available_worker_threads,instance_clr_max_completion_port_threads,instance_clr_max_worker_threads"}]},{"name":"Endpoint","children":[{"width":"4","title":"Endpoint Load in Current Service","height":"280","entityType":"Endpoint","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"endpoint_cpm","queryMetricType":"sortMetrics","chartType":"ChartSlow","parentService":true,"unit":"CPM - calls per minute","maxItemNum":"10"},{"width":"4","title":"Slow Endpoints in Current Service","height":"280","entityType":"Endpoint","independentSelector":false,"metricType":"REGULAR_VALUE","queryMetricType":"sortMetrics","chartType":"ChartSlow","metricName":"endpoint_avg","unit":"ms","parentService":true,"maxItemNum":"10"},{"width":"4","title":"Successful Rate in Current Service","height":"280","entityType":"Endpoint","independentSelector":"false","metricType":"REGULAR_VALUE","metricName":"endpoint_sla","queryMetricType":"sortMetrics","chartType":"ChartSlow","aggregation":"/","aggregationNum":"100","parentService":true,"unit":"%","sortOrder":"ASC","maxItemNum":"10"},{"width":3,"title":"Endpoint Load","height":350,"entityType":"Endpoint","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"endpoint_cpm","queryMetricType":"readMetricsValues","chartType":"ChartLine","maxItemNum":"10"},{"width":3,"title":"Endpoint Avg Response Time","height":350,"entityType":"Endpoint","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"endpoint_avg","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"ms","maxItemNum":"10"},{"width":3,"title":"Endpoint Response Time Percentile","height":350,"entityType":"Endpoint","independentSelector":false,"metricType":"LABELED_VALUE","metricName":"endpoint_percentile","queryMetricType":"readLabeledMetricsValues","chartType":"ChartLine","metricLabels":"P50, P75, P90, P95, P99","labelsIndex":"0, 1, 2, 3, 4","unit":"ms","maxItemNum":"10"},{"width":3,"title":"Endpoint Successful Rate","height":350,"entityType":"Endpoint","independentSelector":false,"metricType":"REGULAR_VALUE","metricName":"endpoint_sla","queryMetricType":"readMetricsValues","chartType":"ChartLine","unit":"%","aggregation":"/","aggregationNum":"100","maxItemNum":"10"}]}]}]`

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
