### PR TITLE
fix: remove the no use maxItemNum for labeled-value metric, etc

### DIFF
--- a/src/views/components/dashboard/charts/chart-edit.vue
+++ b/src/views/components/dashboard/charts/chart-edit.vue
@@ -308,6 +308,7 @@ limitations under the License. -->
     CalculationType,
     ChartTypeOptions,
     ReadValueChartType,
+    MaxItemNum,
   } from './constant';
   import { DASHBOARDTYPE } from '../constant';
 
@@ -372,7 +373,7 @@ limitations under the License. -->
         this.itemConfig.queryMetricType === 'readMetricsValue' ? ReadValueChartType : ChartTypeOptions;
       this.isChartSlow = ['sortMetrics', 'readSampledRecords'].includes(this.itemConfig.queryMetricType);
       if (this.isChartSlow && !this.itemConfig.maxItemNum) {
-        this.itemConfig.maxItemNum = 10;
+        this.itemConfig.maxItemNum = MaxItemNum;
       }
     }
 
@@ -403,7 +404,7 @@ limitations under the License. -->
           this.itemConfig.queryMetricType === 'readMetricsValue' ? ReadValueChartType : ChartTypeOptions;
         this.isChartSlow = ['sortMetrics', 'readSampledRecords'].includes(this.itemConfig.queryMetricType);
         if (this.isChartSlow) {
-          this.itemConfig.maxItemNum = 10;
+          this.itemConfig.maxItemNum = MaxItemNum;
         }
         this.updateQueryMetricType(params);
         return;

--- a/src/views/components/dashboard/charts/chart-edit.vue
+++ b/src/views/components/dashboard/charts/chart-edit.vue
@@ -401,6 +401,10 @@ limitations under the License. -->
       if (params.type === 'queryMetricType') {
         this.chartTypeOptions =
           this.itemConfig.queryMetricType === 'readMetricsValue' ? ReadValueChartType : ChartTypeOptions;
+        this.isChartSlow = ['sortMetrics', 'readSampledRecords'].includes(this.itemConfig.queryMetricType);
+        if (this.isChartSlow) {
+          this.itemConfig.maxItemNum = 10;
+        }
         this.updateQueryMetricType(params);
         return;
       }

--- a/src/views/components/dashboard/charts/chart-edit.vue
+++ b/src/views/components/dashboard/charts/chart-edit.vue
@@ -174,7 +174,7 @@ limitations under the License. -->
           <option v-for="type in IndependentType" :value="type.key" :key="type.key">{{ type.label }}</option>
         </select>
       </div>
-      <div class="flex-h mb-5" v-show="nameMetrics.includes(itemConfig.queryMetricType)">
+      <div class="flex-h mb-5" v-show="isChartSlow">
         <div class="title grey sm">{{ $t('parentService') }}:</div>
         <select
           class="long"
@@ -185,7 +185,7 @@ limitations under the License. -->
           <option :value="false">{{ $t('noneParentService') }}</option>
         </select>
       </div>
-      <div class="flex-h mb-5" v-show="nameMetrics.includes(itemConfig.queryMetricType)">
+      <div class="flex-h mb-5" v-show="isChartSlow">
         <div class="title grey sm">{{ $t('sortOrder') }}:</div>
         <select
           class="long"
@@ -226,7 +226,7 @@ limitations under the License. -->
           @change="setItemConfig({ type: 'height', value: $event.target.value })"
         />
       </div>
-      <div class="flex-h mb-5" v-show="!isChartType">
+      <div class="flex-h mb-5" v-show="isChartSlow">
         <div class="title grey sm">{{ $t('maxItemNum') }}:</div>
         <input
           type="number"
@@ -328,9 +328,6 @@ limitations under the License. -->
     @Prop() private intervalTime!: any;
     @Prop() private type!: string;
     private itemConfig: any = {};
-    private itemConfigDefault: any = {
-      maxItemNum: '10',
-    };
     private EntityType = EntityType;
     private IndependentType = IndependentType;
     private CalculationType = CalculationType;
@@ -343,33 +340,18 @@ limitations under the License. -->
     private isBrowser = false;
     private isLabel = false;
     private isIndependentSelector = false;
-    private nameMetrics = ['sortMetrics', 'readSampledRecords'];
+    private isChartSlow = false;
     private pageTypes = [TopologyType.TOPOLOGY_ENDPOINT, TopologyType.TOPOLOGY_INSTANCE] as string[];
     private isChartType = false;
     private ChartTable = 'ChartTable';
 
     private created() {
-      this.setDefaultValue((this.itemConfig = this.item));
+      this.itemConfig = this.item;
       this.initConfig();
       if (!this.itemConfig.independentSelector || this.pageTypes.includes(this.type)) {
         return;
       }
       this.setItemServices();
-    }
-
-    private setDefaultValue(itemConfig: any) {
-      const currentKeys: string[] = Object.keys(itemConfig);
-      const defaultKeys: string[] = Object.keys(this.itemConfigDefault);
-
-      if (!currentKeys.length || !defaultKeys.length) {
-        return;
-      }
-
-      defaultKeys.forEach((key: string) => {
-        if (!currentKeys.includes(key)) {
-          itemConfig[key] = this.itemConfigDefault[key];
-        }
-      });
     }
 
     private initConfig() {
@@ -388,6 +370,10 @@ limitations under the License. -->
         this.rocketComps.tree[this.rocketComps.group].type === 'metric' || this.pageTypes.includes(this.type);
       this.chartTypeOptions =
         this.itemConfig.queryMetricType === 'readMetricsValue' ? ReadValueChartType : ChartTypeOptions;
+      this.isChartSlow = ['sortMetrics', 'readSampledRecords'].includes(this.itemConfig.queryMetricType);
+      if (this.isChartSlow && !this.itemConfig.maxItemNum) {
+        this.itemConfig.maxItemNum = 10;
+      }
     }
 
     private setItemConfig(params: { type: string; value: string }) {

--- a/src/views/components/dashboard/charts/constant.ts
+++ b/src/views/components/dashboard/charts/constant.ts
@@ -81,3 +81,5 @@ export const ReadValueChartType = [
   { value: 'ChartNum', label: 'Digital Card' },
   { value: 'ChartSlow', label: 'Slow Chart' },
 ];
+
+export const MaxItemNum = 10;


### PR DESCRIPTION
 From @wankai123, remove the no use maxItemNum. 
![1](https://user-images.githubusercontent.com/20871783/117909251-7773f680-b30c-11eb-82c2-b1ee9e71db9e.png)

After fixing
![2](https://user-images.githubusercontent.com/20871783/117909514-f49f6b80-b30c-11eb-912e-3d543f95fd0e.png)

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
