### PR TITLE
fix: add a filter for serviceIds in services topology

### DIFF
--- a/src/views/components/topology/topo-group/index.vue
+++ b/src/views/components/topology/topo-group/index.vue
@@ -84,7 +84,9 @@ limitations under the License. -->
     }
     private handleSelectGroup(id: string) {
       this.SELECT_GROUP(id);
-      this.GET_TOPO({ duration: this.durationTime, serviceIds: this.services.map((i) => i.key) });
+      const serviceIds = this.services.filter((item) => item.key).map((item) => item.key);
+
+      this.GET_TOPO({ duration: this.durationTime, serviceIds });
     }
     private fetchData() {
       return Axios.post('/graphql', {

--- a/src/views/components/topology/topo-services.vue
+++ b/src/views/components/topology/topo-services.vue
@@ -102,7 +102,9 @@ limitations under the License. -->
     }
 
     private getServicesTopo() {
-      const serviceIds = this.group.key ? this.currentServices.map((item) => item.key) : undefined;
+      const serviceIds = this.group.key
+        ? this.currentServices.filter((item) => item.key).map((item) => item.key)
+        : undefined;
 
       this.GET_TOPO({
         serviceIds,


### PR DESCRIPTION
Add a filter for serviceIds in services topology.

Screenshot
![2](https://user-images.githubusercontent.com/20871783/133225606-c340f032-a4a7-47b9-8863-22e5880baa63.png)

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
