### PR TITLE
fix: update the date component css

### DIFF
--- a/src/components/rk-date.vue
+++ b/src/components/rk-date.vue
@@ -392,7 +392,6 @@ limitations under the License. -->
       transform-origin: center top;
     }
     &.left {
-      left: -80px;
       top: 30px;
       transform-origin: center top;
     }


### PR DESCRIPTION
#508 
The display is still incomplete in Chinese

- zh
😖
![069A985D-016B-4753-BD84-363FA835A3D5](https://user-images.githubusercontent.com/5037807/133868197-e947c0e2-cdfe-4bf9-bb57-bca5b3968d5d.png)
- en
![65C89DF1-BAEF-4F59-85E8-488EA4A3C631](https://user-images.githubusercontent.com/5037807/133868213-6e627098-7cee-4603-b8d7-c2d0f984b9f3.png)
-----

I suggest removing ```left: - 80px;```, why ```-80px?``` here, If delete it, It can be displayed normally in multiple languages

- zh
![03AF9267-5280-434D-AAF3-8A8CE18EAA87](https://user-images.githubusercontent.com/5037807/133868420-7dd5fb28-55f8-4d6f-bb77-4dc2a9431ff8.png)

- en
![BD4ABFE7-A7A3-45F6-826D-B86C5D1FA6A5](https://user-images.githubusercontent.com/5037807/133868424-d7ca09d1-7926-4bce-99cc-e4682a79cc08.png)



