### PR TITLE
No longer check if the previous span exists

### DIFF
--- a/src/views/components/trace/trace-detail-chart-list.vue
+++ b/src/views/components/trace/trace-detail-chart-list.vue
@@ -123,13 +123,13 @@ limitations under the License. -->
             const index = this.data.findIndex((i) => (
               i.segmentId === span.segmentId
               &&
-              i.spanId === (span.spanId - 1)
+              i.spanId === span.parentSpanId
             ));
             const fixSpanKeyContent = {
               traceId: span.traceId,
               segmentId: span.segmentId,
-              spanId: span.spanId - 1,
-              parentSpanId: span.spanId - 2,
+              spanId: span.parentSpanId,
+              parentSpanId: span.parentSpanId - 1,
             };
             if (index === -1 && !_.find(fixSpans, fixSpanKeyContent)) {
               fixSpans.push(

--- a/src/views/components/trace/trace-detail-chart-tree.vue
+++ b/src/views/components/trace/trace-detail-chart-tree.vue
@@ -105,12 +105,12 @@ limitations under the License. -->
             if (span.parentSpanId === -1) {
               segmentHeaders.push(span);
             } else {
-              const index = this.data.findIndex(i => (i.segmentId === span.segmentId && i.spanId === (span.spanId - 1)));
+              const index = this.data.findIndex(i => (i.segmentId === span.segmentId && i.spanId === span.parentSpanId));
               const fixSpanKeyContent = {
                 traceId: span.traceId,
                 segmentId: span.segmentId,
-                spanId: span.spanId - 1,
-                parentSpanId: span.spanId - 2,
+                spanId: span.parentSpanId,
+                parentSpanId: span.parentSpanId - 1,
               };
               if (index === -1 && !_.find(fixSpans, fixSpanKeyContent)) {
                 fixSpans.push(

--- a/src/views/components/trace/trace-util.ts
+++ b/src/views/components/trace/trace-util.ts
@@ -90,13 +90,13 @@ export default class TraceUtil {
         segmentHeaders.push(span);
       } else {
         const index = data.findIndex((patchSpan: Span) => {
-          return patchSpan.segmentId === span.segmentId && patchSpan.spanId === span.spanId - 1;
+          return patchSpan.segmentId === span.segmentId && patchSpan.spanId === span.parentSpanId;
         });
         const fixSpanKeyContent = {
           traceId: span.traceId,
           segmentId: span.segmentId,
-          spanId: span.spanId - 1,
-          parentSpanId: span.spanId - 2,
+          spanId: span.parentSpanId,
+          parentSpanId: span.parentSpanId - 1,
         };
         if (index === -1 && !lodash.find(fixSpans, fixSpanKeyContent)) {
           fixSpans.push({


### PR DESCRIPTION
https://github.com/apache/skywalking-rocketbot-ui/blob/8a6514d019f1875916719b2de30ce519a5f8e8fc/src/views/components/trace/trace-detail-chart-list.vue#L123-L133
I think it is better to check if the parent span exists than previous span(spanId - 1). I'm writing a client logic, and the spanId might be discontinuous, some of the spanIds will be discard. So I did these changes.